### PR TITLE
Add option for custom config

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 # EXAMPLE=animated_shapes
 # EXAMPLE=animated_text
 # EXAMPLE=animated_sprites
+EXAMPLE=custom_config
 # EXAMPLE=custom_fonts
 # EXAMPLE=ecs_sprite
 # EXAMPLE=ecs_topdown_game
@@ -11,7 +12,7 @@
 # EXAMPLE=particle_systems
 # EXAMPLE=physics
 # EXAMPLE=post_processing
-EXAMPLE=sprite
+# EXAMPLE=sprite
 # EXAMPLE=shapes
 # EXAMPLE=sound
 # EXAMPLE=text

--- a/comfy-core/src/config.rs
+++ b/comfy-core/src/config.rs
@@ -2,9 +2,26 @@ use crate::*;
 
 pub const COMBAT_TEXT_LIFETIME: f32 = 0.4;
 
-#[derive(Copy, Clone, Debug, Default)]
-pub struct ShipConfig {
-    pub auto_disengage_angular_autopilot: bool,
+#[derive(Copy, Clone, Debug)]
+pub enum ResolutionConfig {
+    Physical(u32, u32),
+    Logical(u32, u32),
+}
+
+impl ResolutionConfig {
+    pub fn width(&self) -> u32 {
+        match self {
+            Self::Physical(w, _) => *w,
+            Self::Logical(w, _) => *w,
+        }
+    }
+
+    pub fn height(&self) -> u32 {
+        match self {
+            Self::Physical(_, h) => *h,
+            Self::Logical(_, h) => *h,
+        }
+    }
 }
 
 #[derive(Copy, Clone, Debug)]
@@ -12,7 +29,7 @@ pub struct GameConfig {
     pub game_name: &'static str,
     pub version: &'static str,
 
-    pub ship: ShipConfig,
+    pub resolution: ResolutionConfig,
 
     pub lighting: GlobalLightingParams,
     pub lighting_enabled: bool,
@@ -31,11 +48,16 @@ pub struct GameConfig {
 
 impl Default for GameConfig {
     fn default() -> Self {
+        #[cfg(target_arch = "wasm32")]
+        let resolution = ResolutionConfig::Logical(1106, 526);
+        #[cfg(not(target_arch = "wasm32"))]
+        let resolution = ResolutionConfig::Physical(1920, 1080);
+
         Self {
             game_name: "TODO_GAME_NAME",
             version: "TODO_VERSION",
 
-            ship: ShipConfig::default(),
+            resolution,
 
             lighting: GlobalLightingParams::default(),
             lighting_enabled: false,

--- a/comfy-core/src/lib.rs
+++ b/comfy-core/src/lib.rs
@@ -1094,8 +1094,8 @@ macro_rules! define_versions {
     () => {
         // pub const GIT_VERSION: &str = git_version::git_version!();
 
-        lazy_static! {
-            pub static ref VERSION: SemanticVer = SemanticVer {
+        $crate::lazy_static! {
+            pub static ref VERSION: $crate::SemanticVer = $crate::SemanticVer {
                 major: env!("CARGO_PKG_VERSION_MAJOR").parse().unwrap(),
                 minor: env!("CARGO_PKG_VERSION_MINOR").parse().unwrap(),
                 patch: env!("CARGO_PKG_VERSION_PATCH").parse().unwrap(),

--- a/comfy-wgpu/src/renderer.rs
+++ b/comfy-wgpu/src/renderer.rs
@@ -960,7 +960,7 @@ impl WgpuRenderer {
 
         let paint_jobs =
             self.egui_render_routine.borrow_mut().end_frame_and_render(
-                &params.egui,
+                params.egui,
                 &self.context.device,
                 &self.context.queue,
                 &mut encoder,

--- a/comfy/examples/custom_config.rs
+++ b/comfy/examples/custom_config.rs
@@ -1,0 +1,24 @@
+use comfy::*;
+
+simple_game!("Nice red circle", GameState, config, setup, update);
+
+fn config(config: GameConfig) -> GameConfig {
+    GameConfig {
+        resolution: ResolutionConfig::Physical(600, 600 * 16 / 9),
+        ..config
+    }
+}
+
+pub struct GameState {}
+
+impl GameState {
+    pub fn new(_c: &EngineContext) -> Self {
+        Self {}
+    }
+}
+
+fn setup(_state: &mut GameState, _c: &mut EngineContext) {}
+
+fn update(_state: &mut GameState, _c: &mut EngineContext) {
+    draw_text("Comfy likes portrait mode", Vec2::ZERO, PINK, TextAlign::Center);
+}

--- a/comfy/src/engine.rs
+++ b/comfy/src/engine.rs
@@ -6,8 +6,6 @@ pub trait GameLoop {
     fn performance_metrics(&self, _world: &mut World, _ui: &mut egui::Ui) {}
     fn engine(&mut self) -> &mut EngineState;
     fn update(&mut self);
-    // fn early_update(&mut self, _c: &mut EngineContext) {}
-    // fn late_update(&mut self, _c: &mut EngineContext) {}
 }
 
 pub type GameLoopBuilder = Box<dyn Fn() -> Arc<Mutex<dyn GameLoop>>>;

--- a/comfy/src/macros.rs
+++ b/comfy/src/macros.rs
@@ -80,6 +80,7 @@ macro_rules! simple_game {
             ComfyGameContext,
             $state,
             _comfy_make_context,
+            $config,
             _comfy_setup_context,
             _comfy_update_context,
         }
@@ -89,7 +90,7 @@ macro_rules! simple_game {
         $crate::simple_game! {
             $name,
             $state,
-            _comfy_empty_config,
+            _comfy_default_config,
             $setup,
             $update,
         }
@@ -137,10 +138,7 @@ macro_rules! simple_game {
     ($name:literal, $update:ident $(,)?) => {
         #[inline]
         #[doc(hidden)]
-        fn _comfy_setup_empty_context(
-            _context: &mut $crate::EngineContext<'_>,
-        ) {
-        }
+        fn _comfy_setup_empty_context(_context: &mut EngineContext<'_>) {}
 
         simple_game!($name, _comfy_setup_empty_context, $update);
     };


### PR DESCRIPTION
This PR changes `simple_game` and `comfy_game` to also optionally accept a config function

```rust
pub fn config(config: GameConfig) -> GameConfig {
    GameConfig {
        // change defaults here
        ..config
    }
}
```

The reason it accepts `config` and doesn't use `Default::default()` is because some of the default values are dependent on the macro invocation itself, e.g. the game's name. We may find a better way of doing the whole setup in the future, but for now this seems better than just duplicating the name or adding more paths to the macros. Existing code should remain 100% unaffected.