### PR TITLE
Fixes: minimizing game leads to crash

### DIFF
--- a/comfy-core/src/config.rs
+++ b/comfy-core/src/config.rs
@@ -22,6 +22,18 @@ impl ResolutionConfig {
             Self::Logical(_, h) => *h,
         }
     }
+
+    pub fn ensure_non_zero(&mut self) -> ResolutionConfig{
+        const MIN_WINDOW_SIZE: u32 = 1;
+        match self {
+            ResolutionConfig::Physical(w, h) | ResolutionConfig::Logical(w, h) if *w <= 0 || *h <= 0 => {
+                *w = MIN_WINDOW_SIZE;
+                *h = MIN_WINDOW_SIZE;
+            },
+            _ => (),
+        }  
+        self.clone()
+    }
 }
 
 #[derive(Copy, Clone, Debug)]

--- a/comfy-core/src/config.rs
+++ b/comfy-core/src/config.rs
@@ -30,6 +30,7 @@ pub struct GameConfig {
     pub version: &'static str,
 
     pub resolution: ResolutionConfig,
+    pub min_resolution: ResolutionConfig,
 
     pub bloom_enabled: bool,
     pub lighting: GlobalLightingParams,
@@ -54,11 +55,17 @@ impl Default for GameConfig {
         #[cfg(not(target_arch = "wasm32"))]
         let resolution = ResolutionConfig::Physical(1920, 1080);
 
+        #[cfg(target_arch = "wasm32")]
+        let min_resolution = ResolutionConfig::Logical(200, 100);
+        #[cfg(not(target_arch = "wasm32"))]
+        let min_resolution = ResolutionConfig::Physical(200, 100);
+
         Self {
             game_name: "TODO_GAME_NAME",
             version: "TODO_VERSION",
 
             resolution,
+            min_resolution,
 
             bloom_enabled: false,
             lighting: GlobalLightingParams::default(),

--- a/comfy-core/src/config.rs
+++ b/comfy-core/src/config.rs
@@ -56,9 +56,9 @@ impl Default for GameConfig {
         let resolution = ResolutionConfig::Physical(1920, 1080);
 
         #[cfg(target_arch = "wasm32")]
-        let min_resolution = ResolutionConfig::Logical(200, 100);
+        let min_resolution = ResolutionConfig::Logical(1, 1);
         #[cfg(not(target_arch = "wasm32"))]
-        let min_resolution = ResolutionConfig::Physical(200, 100);
+        let min_resolution = ResolutionConfig::Physical(1, 1);
 
         Self {
             game_name: "TODO_GAME_NAME",

--- a/comfy-wgpu/src/renderer.rs
+++ b/comfy-wgpu/src/renderer.rs
@@ -1638,19 +1638,16 @@ impl WgpuRenderer {
 
         let scale_factor = self.window.scale_factor() as f32;
 
-        let new_size =
+        self.size =
             winit::dpi::PhysicalSize::<u32>::new(new_size.x, new_size.y);
 
-        if new_size.width > 0 && new_size.height > 0 {
-            self.size = new_size;
-            self.config.width = new_size.width;
-            self.config.height = new_size.height;
-            self.surface.configure(&self.context.device, &self.config);
-        }
+        self.config.width =  self.size.width;
+        self.config.height = self.size.height;
+        self.surface.configure(&self.context.device, &self.config);
 
         self.egui_render_routine.borrow_mut().resize(
-            new_size.width,
-            new_size.height,
+            self.size.width,
+            self.size.height,
             scale_factor,
         );
 

--- a/comfy-wgpu/src/renderer.rs
+++ b/comfy-wgpu/src/renderer.rs
@@ -972,7 +972,6 @@ impl WgpuRenderer {
         {
             let mut render_pass =
                 encoder.simple_render_pass("egui Render Pass", None, view);
-
             egui_render.render_pass.render(
                 &mut render_pass,
                 &paint_jobs,
@@ -1487,9 +1486,9 @@ impl WgpuRenderer {
     pub fn draw(&mut self, params: DrawParams) {
         span_with_timing!("render");
 
-        let output = {
-            let _span = span!("get current surface");
-            self.surface.get_current_texture().unwrap()
+        let output = match self.surface.get_current_texture() {
+            Ok(texture) => texture,
+            Err(_) => { return; }
         };
 
         let surface_view = {

--- a/comfy/examples/custom_config.rs
+++ b/comfy/examples/custom_config.rs
@@ -5,6 +5,7 @@ simple_game!("Nice red circle", GameState, config, setup, update);
 fn config(config: GameConfig) -> GameConfig {
     GameConfig {
         resolution: ResolutionConfig::Physical(600, 600 * 16 / 9),
+        min_resolution: ResolutionConfig::Physical(100, 100* 16 / 9),
         ..config
     }
 }

--- a/comfy/src/game_loop.rs
+++ b/comfy/src/game_loop.rs
@@ -28,8 +28,18 @@ pub async fn run_comfy_main_async(mut game: impl GameLoop + 'static) {
         }
     };
 
-
     let window = window.build(&event_loop).unwrap();
+
+    let min_resolution = game.engine().config.get_mut().min_resolution;
+
+    match min_resolution {
+        ResolutionConfig::Physical(w, h) => {
+            window.set_min_inner_size(Some(winit::dpi::PhysicalSize::new(w, h)))
+        }
+        ResolutionConfig::Logical(w, h) => {
+            window.set_min_inner_size(Some(winit::dpi::LogicalSize::new(w, h)))
+        }
+    }
 
     #[cfg(target_arch = "wasm32")]
     {
@@ -202,12 +212,10 @@ pub async fn run_comfy_main_async(mut game: impl GameLoop + 'static) {
                     }
 
                     WindowEvent::Resized(physical_size) => {
-                        if physical_size.width > 0  && physical_size.height > 0 {
-                            game.engine().resize(uvec2(
-                                physical_size.width,
-                                physical_size.height,
-                            ));
-                        }
+                        game.engine().resize(uvec2(
+                            physical_size.width,
+                            physical_size.height,
+                        ));
                     }
 
                     WindowEvent::ScaleFactorChanged {

--- a/comfy/src/game_loop.rs
+++ b/comfy/src/game_loop.rs
@@ -30,16 +30,16 @@ pub async fn run_comfy_main_async(mut game: impl GameLoop + 'static) {
 
     let window = window.build(&event_loop).unwrap();
 
-    let min_resolution = game.engine().config.get_mut().min_resolution;
-
-    match min_resolution {
+    let min_resolution = match game.engine().config.get_mut().min_resolution {
         ResolutionConfig::Physical(w, h) => {
-            window.set_min_inner_size(Some(winit::dpi::PhysicalSize::new(w, h)))
+            window.set_min_inner_size(Some(winit::dpi::PhysicalSize::new(w, h)));
+            (w, h)
         }
         ResolutionConfig::Logical(w, h) => {
-            window.set_min_inner_size(Some(winit::dpi::LogicalSize::new(w, h)))
+            window.set_min_inner_size(Some(winit::dpi::LogicalSize::new(w, h)));
+            (w, h)
         }
-    }
+    };
 
     #[cfg(target_arch = "wasm32")]
     {
@@ -212,10 +212,12 @@ pub async fn run_comfy_main_async(mut game: impl GameLoop + 'static) {
                     }
 
                     WindowEvent::Resized(physical_size) => {
-                        game.engine().resize(uvec2(
-                            physical_size.width,
-                            physical_size.height,
-                        ));
+                        if physical_size.width > min_resolution.0 && physical_size.height > min_resolution.1 {
+                            game.engine().resize(uvec2(
+                                physical_size.width,
+                                physical_size.height,
+                            ));
+                        }
                     }
 
                     WindowEvent::ScaleFactorChanged {

--- a/comfy/src/game_loop.rs
+++ b/comfy/src/game_loop.rs
@@ -30,7 +30,7 @@ pub async fn run_comfy_main_async(mut game: impl GameLoop + 'static) {
 
     let window = window.build(&event_loop).unwrap();
 
-    let min_resolution = match game.engine().config.get_mut().min_resolution {
+    let min_resolution = match  game.engine().config.get_mut().min_resolution.ensure_non_zero() {
         ResolutionConfig::Physical(w, h) => {
             window.set_min_inner_size(Some(winit::dpi::PhysicalSize::new(w, h)));
             (w, h)
@@ -40,6 +40,8 @@ pub async fn run_comfy_main_async(mut game: impl GameLoop + 'static) {
             (w, h)
         }
     };
+
+    println!("{:?}", min_resolution);
 
     #[cfg(target_arch = "wasm32")]
     {

--- a/comfy/src/game_loop.rs
+++ b/comfy/src/game_loop.rs
@@ -202,10 +202,12 @@ pub async fn run_comfy_main_async(mut game: impl GameLoop + 'static) {
                     }
 
                     WindowEvent::Resized(physical_size) => {
-                        game.engine().resize(uvec2(
-                            physical_size.width,
-                            physical_size.height,
-                        ));
+                        if physical_size.width > 0  && physical_size.height > 0 {
+                            game.engine().resize(uvec2(
+                                physical_size.width,
+                                physical_size.height,
+                            ));
+                        }
                     }
 
                     WindowEvent::ScaleFactorChanged {

--- a/comfy/src/game_loop.rs
+++ b/comfy/src/game_loop.rs
@@ -41,8 +41,6 @@ pub async fn run_comfy_main_async(mut game: impl GameLoop + 'static) {
         }
     };
 
-    println!("{:?}", min_resolution);
-
     #[cfg(target_arch = "wasm32")]
     {
         // Winit prevents sizing with CSS, so we have to set


### PR DESCRIPTION
This change fixes the issue #12 

In the event_loops, the resize function is invoked only when both the width and height are greater than zero. This ensures that resizing operations are performed when a valid window size is detected.

In the `WgpuRenderer::draw` method, a match statement is used to ascertain the availability of the current texture. In cases where the texture is unavailable, failing to handle this condition properly can result in errors when the window is minimized or in similar scenarios.

These changes effectively prevent the `draw` method from being called when the window is minimized. It's important to consider whether this approach aligns with the desired behavior for the engine.