### PR TITLE
Prevent panic when calculating movement vector.

### DIFF
--- a/comfy/examples/ecs_topdown_game.rs
+++ b/comfy/examples/ecs_topdown_game.rs
@@ -95,7 +95,7 @@ fn update(c: &mut EngineContext) {
 
         if moved {
             animated_sprite.flip_x = move_dir.x < 0.0;
-            transform.position += move_dir.normalize() * speed * dt;
+            transform.position += move_dir.normalize_or_zero() * speed * dt;
             animated_sprite.play("walk");
         } else {
             animated_sprite.play("idle");


### PR DESCRIPTION
This change will use `normalize_or_zero()` instead of the previously, panicking `normalize()`. 