### PR TITLE
Support background load for audio and progress info

### DIFF
--- a/comfy-core/src/assets.rs
+++ b/comfy-core/src/assets.rs
@@ -231,12 +231,14 @@ impl Assets {
                     .collect();
 
                 let mut queue = current_queue.lock();
+                let new_asset_count = texture_queue.len();
 
                 if let Some(queue) = queue.as_mut() {
                     queue.extend(texture_queue);
                 } else {
                     *queue = Some(texture_queue);
                 }
+                add_assets_loaded(new_asset_count);
             }
         }
 
@@ -292,6 +294,7 @@ impl Assets {
                             Ok(sound) => {
                                 trace!("Sound {}", item_path);
                                 sounds.lock().insert(handle, sound);
+                                add_assets_loaded(1);
                             }
                             Err(err) => {
                                 error!(

--- a/comfy-core/src/global_state.rs
+++ b/comfy-core/src/global_state.rs
@@ -1,4 +1,4 @@
-use std::sync::atomic::{AtomicU32, AtomicU64, Ordering};
+use std::sync::atomic::{AtomicU32, AtomicU64, AtomicUsize, Ordering};
 
 use crate::*;
 
@@ -15,6 +15,16 @@ static TIME: AtomicU64 = AtomicU64::new(unsafe { std::mem::transmute(0.0f64) });
 
 static UNPAUSED_TIME: AtomicU64 =
     AtomicU64::new(unsafe { std::mem::transmute(0.0f64) });
+
+static ASSETS_LOADED: AtomicUsize = AtomicUsize::new(0);
+
+pub fn assets_loaded() -> usize {
+    ASSETS_LOADED.load(Ordering::SeqCst)
+}
+
+pub fn add_assets_loaded(newly_loaded_count: usize) {
+    ASSETS_LOADED.fetch_add(newly_loaded_count, Ordering::SeqCst);
+}
 
 pub fn frame_time() -> f32 {
     f32::from_bits(FRAME_TIME.load(Ordering::SeqCst))


### PR DESCRIPTION
Sound/music loading was happening in render thread. This change moves it to rayon threadpool.

There are two updates:
1. Move file content loading in thread pool.
2. Use `pool.spawn` instead of the blocking `pool.install` which was causing file parsing to block render thread.
3. Support for loading screen by having new assets_loaded() function.

Testing:
1. OK: Absolute path codepath for loading
2. NOT TESTED: WASM code path. If anyone else can test it please do.
3. OK: verified assets_loaded() returns # of textures and images correctly.
4. Not sure if I missed a test - let me know and/or please check yourself :)

**WARNING!** If this PR is merged, first or early music/sound played may stop working because it may not be asynchronously loaded. For example, main menu music may stop working since play() is called before load completes.
It is up to the developer to verify if assets have been loaded by calling `assets_loaded()` which will return a number of assets loaded so far. This can be used for a progress bar. 

Example:
```rust
        draw_text(
            &format!("Loaded assets: {}", assets_loaded()),
            vec2(0.0, 1.0),
            WHITE,
            TextAlign::Center,
        );
```
![async_load](https://github.com/darthdeus/comfy/assets/6869225/435766c4-c61a-4756-bf9a-07803a21523b)
