### PR TITLE
compress vertex color data to [u8;4]

### DIFF
--- a/comfy-core/src/lib.rs
+++ b/comfy-core/src/lib.rs
@@ -582,7 +582,7 @@ pub struct RawDrawParams {
     pub pivot: Option<Vec2>,
 }
 
-const WHITE_ARRAY: [f32; 4] = [1.0, 1.0, 1.0, 1.0];
+const WHITE_ARRAY: [u8; 4] = [255, 255, 255, 255];
 
 pub const QUAD_VERTICES: &[SpriteVertex] = &[
     SpriteVertex {
@@ -620,7 +620,7 @@ pub struct Mesh {
 pub struct SpriteVertex {
     pub position: [f32; 3],
     pub tex_coords: [f32; 2],
-    pub color: [f32; 4],
+    pub color: [u8; 4],
 }
 
 impl SpriteVertex {
@@ -628,7 +628,7 @@ impl SpriteVertex {
         Self {
             position: [position.x, position.y, position.z],
             tex_coords: [tex_coords.x, tex_coords.y],
-            color: [color.r, color.g, color.b, color.a],
+            color: color.to_array(),
         }
     }
 }

--- a/comfy-wgpu/src/lib.rs
+++ b/comfy-wgpu/src/lib.rs
@@ -54,7 +54,7 @@ pub trait Vertex {
 const ATTRIBS: [wgpu::VertexAttribute; 3] = wgpu::vertex_attr_array![
     0 => Float32x3,
     1 => Float32x2,
-    2 => Float32x4,
+    2 => Unorm8x4,
 ];
 
 impl Vertex for SpriteVertex {


### PR DESCRIPTION
Hi, I saw your chat on reddit when you first released comfy, talking about bunnymark performance, and now that I've seen your official benchmark I thought I would try to contribute an improvement.

This changes vertices to use a [u8;4], with rgba ranging from 0-255, rather than a [f32;4] to represent color data - the gpu automatically reconstructs it as a vec4 in the shader, so no shader changes are needed. The main benefit of doing this is decreasing the bandwidth for transferring vertex data from sys mem -> gpu mem. Since color data has to be repeated for each vertex, it adds a lot of bulk to the vertex buffer.

For 2D tests like a bunnymark, cutting down on buffer size is the biggest bottleneck for most frameworks (even before game/engine logic). Most bunnymarks out there have a CPU bottleneck because uploading all that data is a blocking operation. based on your comfymark target of 50fps, on my system (linux, r9 5900x, rtx2070) - this change brought the comfymark being capable of ~45,000 up to ~65,000.

I am not super familar with the inner workings of wgpu (im most familiar with pure opengl), or anything specific you do in comfy. It does seem like your framework's entity/world concept probably does create some overhead which is to be expected, and will probably limit a benchmark like this in the end - but there are some other changes to the pipeline that could reduce the 'bandwidth' issue further - though they'd require more complex/invasive changes than this PR

If you'd like I'd be happy to talk more specifics about optimizing the sprite rendering - I've put a good amount of time into figuring out specifically the bunnymark, so it'd be nice to be able to share some of that ahaha