### PR TITLE
feature: add wayland support

### DIFF
--- a/comfy-core/Cargo.toml
+++ b/comfy-core/Cargo.toml
@@ -20,6 +20,8 @@ memprof = ["tracy"]
 lua = ["mlua"]
 blobs = ["dep:blobs"]
 
+wayland = ["winit/wayland"]
+
 [dependencies]
 smallvec = "1.10.0"
 

--- a/comfy/Cargo.toml
+++ b/comfy/Cargo.toml
@@ -30,6 +30,8 @@ tracy = ["comfy-core/tracy", "comfy-wgpu/tracy"]
 jemalloc = ["comfy-core/jemalloc"]
 lua = ["comfy-core/lua"]
 
+wayland = ["comfy-core/wayland"]
+
 [dependencies]
 comfy-wgpu = { path = "../comfy-wgpu", version = "0.2.0" }
 comfy-core = { path = "../comfy-core", version = "0.2.0" }

--- a/comfy/Cargo.toml
+++ b/comfy/Cargo.toml
@@ -22,7 +22,7 @@ demo = []
 dev = []
 embedded-assets = []
 quick-exit = []
-ci-release = ["comfy-core/ci-release", "comfy-wgpu/ci-release"]
+ci-release = ["comfy-core/ci-release", "comfy-wgpu/ci-release", "wayland"]
 
 tracy = ["comfy-core/tracy", "comfy-wgpu/tracy"]
 # tracy = ["comfy-core/tracy", "blobs/tracy", "comfy-wgpu/tracy"]

--- a/flake.nix
+++ b/flake.nix
@@ -46,11 +46,14 @@
             vulkan-loader
             vulkan-validation-layers
 
-            # wayland
+            # X
             xorg.libX11
             xorg.libXcursor
             xorg.libXi
             xorg.libXrandr
+
+            # wayland
+            wayland
 
             # extra tooling
             tracy # profiler, call with ~Tracy~
@@ -66,6 +69,8 @@
               vulkan-loader
 
               # wayland
+              wayland
+
               # xstuff
               xorg.libX11
               xorg.libXcursor


### PR DESCRIPTION
This resolves #51 

I'm not sure if I should also update the `Cargo.lock` in the repo, but I guess it's ok not to do it. 

Btw: Isn't the standard way of doing things in rust not shipping the `Cargo.lock` with library crates anyways?