### PR TITLE
CI cache improvements

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,16 +24,6 @@ jobs:
       - name: Remove cargo config for incremental builds
         run: rm -f .cargo/config.toml
 
-      - uses: actions/cache@v3
-        with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            target/
-          key: ${{ runner.os }}-cargo-build-nightly-${{ hashFiles('**/Cargo.toml') }}
-
       - uses: dtolnay/rust-toolchain@nightly
         with:
           components: clippy, rustfmt
@@ -43,12 +33,15 @@ jobs:
         if: runner.os == 'linux'
 
       - name: Cache rust modules
-        uses: Swatinem/rust-cache@v2.0.1
+        uses: Swatinem/rust-cache@v2.7.0
         with:
           cache-on-failure: true
           shared-key: ubuntu-build
 
-      - name: Build & run tests
+      - name: Build tests
+        run: cargo test --features blobs --no-run
+
+      - name: Run tests
         run: cargo test --features blobs
 
       - name: Build all examples


### PR DESCRIPTION
Changes:
- Update Swatinem/rust-cache (2.0.1 -> 2.7.0)
- No more 2 competing cache actions
- Separate test build and run steps, so it's clear how long each takes