### PR TITLE
Make font handle internal id public

### DIFF
--- a/comfy-core/src/text.rs
+++ b/comfy-core/src/text.rs
@@ -98,8 +98,10 @@ pub fn gen_font_handle() -> FontHandle {
     )
 }
 
+/// Opaque handle to a font. The ID is exposed for debugging purposes.
+/// If you set it manually, you're on your own!
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
-pub struct FontHandle(u64);
+pub struct FontHandle(pub u64);
 
 fn draw_text_internal(
     text: TextData,


### PR DESCRIPTION
Make inner id of FontHandle public, to align it with all other handle / id types. I used a similar docstring to the one in `ShaderId`.