### PR TITLE
Allow z-index in draw text experimental

### DIFF
--- a/comfy-core/src/text.rs
+++ b/comfy-core/src/text.rs
@@ -81,13 +81,14 @@ pub fn draw_text_pro_experimental(
     align: TextAlign,
     font_size: f32,
     font: FontHandle,
+    z_index: i32,
 ) {
     draw_text_internal(
         TextData::Rich(text),
         position,
         align,
         Some(ProTextParams { font_size, font }),
-        TextParams { color, ..Default::default() },
+        TextParams { color, z_index, ..Default::default() },
     );
 }
 

--- a/comfy/examples/text.rs
+++ b/comfy/examples/text.rs
@@ -47,6 +47,7 @@ fn update(state: &mut GameState, _c: &mut EngineContext) {
         } else {
             state.fonts[1]
         },
+        100,
     );
 
     let alignments = [
@@ -72,6 +73,7 @@ fn update(state: &mut GameState, _c: &mut EngineContext) {
             align,
             state.font_size,
             state.fonts[0],
+            100,
         );
     }
 

--- a/comfy/examples/z_index_test.rs
+++ b/comfy/examples/z_index_test.rs
@@ -59,6 +59,7 @@ fn update(state: &mut GameState, _c: &mut EngineContext) {
                 TextAlign::Center,
                 32.0,
                 state.font,
+                100,
             );
 
             draw_circle(

--- a/comfy/src/update_stages.rs
+++ b/comfy/src/update_stages.rs
@@ -314,7 +314,7 @@ fn render_text(c: &mut EngineContext) {
                     texture,
                     pos,
                     color,
-                    100,
+                    text.z_index,
                     DrawTextureProParams {
                         source_rect: Some(source_rect),
                         align: SpriteAlign::BottomLeft,


### PR DESCRIPTION
The new text API did not allow using a Z index, and the Z index value was ignored internally.