### PR TITLE
Update ASSETS_LOADED one frame later so users can skip the placeholder.

### DIFF
--- a/comfy-core/src/global_state.rs
+++ b/comfy-core/src/global_state.rs
@@ -24,6 +24,7 @@ static UNPAUSED_TIME: AtomicU64 =
 
 static ASSETS_QUEUED: AtomicUsize = AtomicUsize::new(0);
 static ASSETS_LOADED: AtomicUsize = AtomicUsize::new(0);
+static ASSETS_LOADED_THIS_FRAME: AtomicUsize = AtomicUsize::new(0);
 
 /// Returns the total number of assets queued for loading
 /// by the parallel asset loader.
@@ -46,9 +47,14 @@ pub fn assets_loaded() -> usize {
 }
 
 pub fn inc_assets_loaded(newly_loaded_count: usize) {
-    ASSETS_LOADED.fetch_add(newly_loaded_count, Ordering::SeqCst);
+    ASSETS_LOADED_THIS_FRAME.fetch_add(newly_loaded_count, Ordering::SeqCst);
 }
 
+pub fn apply_assets_loaded_this_frame() {
+    let assets_loaded_this_frame =
+        ASSETS_LOADED_THIS_FRAME.swap(0, Ordering::SeqCst);
+    ASSETS_LOADED.fetch_add(assets_loaded_this_frame, Ordering::SeqCst);
+}
 
 pub fn frame_time() -> f32 {
     f32::from_bits(FRAME_TIME.load(Ordering::SeqCst))

--- a/comfy/src/update_stages.rs
+++ b/comfy/src/update_stages.rs
@@ -55,6 +55,7 @@ fn run_mid_update_stages(c: &mut EngineContext) {
 
 // TODO: Some of the ordering in the update stages is definitely incorrect.
 pub(crate) fn run_late_update_stages(c: &mut EngineContext, delta: f32) {
+    apply_assets_loaded_this_frame();
     update_animated_sprites(c);
     update_trails(c);
     update_drawables(c);


### PR DESCRIPTION
When textures are rendered, there is a placeholder image that flashes for a single frame before the actual image. Here is an example of how it looks:

<img width="100" alt="Screenshot 2024-01-13 at 5 59 11 PM" src="https://github.com/darthdeus/comfy/assets/590450/1413e5a5-fb68-452e-b3b5-738ec4a51802">

Example reproduction:

```rust
impl GameLoop for Game {
    fn new(_c: &mut EngineState) -> Self {
        load_multiple_textures(
            // Includes the "monkey" texture.
            crate::constants::TEXTURES
                .iter()
                .map(|(a, b)| (a.to_string(), b.to_string()))
                .collect_vec(),
        );

        clear_background(BLACK);
        Self
    }

    fn update(&mut self, c: &mut EngineContext) {
        if assets_loaded() < assets_queued_total() {
            println!("{}/{} loaded", assets_loaded(), assets_queued_total());
            return;
        }

        draw_sprite(
            texture_id("monkey"),
            vec2(5.0, 0.0),
            WHITE,
            0,
            vec2(2.60, 3.15),
        );
    }
}
```
Here's my attempt to track it down:

1. `run_early_update_stages()` [processes the asset queues](https://github.com/darthdeus/comfy/blob/master/comfy/src/update_stages.rs#L18)...
2. ...and then spawns an async task that does [`inc_assets_loaded()`](https://github.com/darthdeus/comfy/blob/master/comfy-core/src/asset_loader.rs#L102) saying it is "loaded." It is not actually loaded yet.
3. The renderer update [can't find the texture and instead defaults to the "error" texture id](https://github.com/darthdeus/comfy/blob/84cddaae027ce2a1898bc76b5fe64821aebc01fa/comfy-wgpu/src/batching.rs#L274), which is very similar to that image I linked above.
4. Sometime between the renderer update and the next frame, the texture gets loaded. I am still not sure where this hapens.

Fix in this branch. We just put off the rendering by 1 frame.