### PR TITLE
Fix keyboard event detection

### DIFF
--- a/comfy/src/game_loop.rs
+++ b/comfy/src/game_loop.rs
@@ -222,6 +222,32 @@ pub async fn run_comfy_main_async(
                     }
 
                     match event {
+                        WindowEvent::KeyboardInput {event, ..} => {
+                            if let Some(keycode) =
+                                KeyCode::try_from_winit(event.physical_key)
+                            {
+                                match event.state {
+                                    ElementState::Pressed => {
+                                        let mut state =
+                                            GLOBAL_STATE.borrow_mut();
+
+                                        state.pressed.insert(keycode);
+                                        state.just_pressed.insert(keycode);
+                                        state.just_released.remove(&keycode);
+                                    }
+
+                                    ElementState::Released => {
+                                        let mut state =
+                                            GLOBAL_STATE.borrow_mut();
+
+                                        state.pressed.remove(&keycode);
+                                        state.just_pressed.remove(&keycode);
+                                        state.just_released.insert(keycode);
+                                    }
+                                }
+                            }
+                        }
+
                         WindowEvent::CursorMoved { position, .. } => {
                             let mut global_state = GLOBAL_STATE.borrow_mut();
 
@@ -299,32 +325,6 @@ pub async fn run_comfy_main_async(
                             }
                         }
                         
-                        WindowEvent::KeyboardInput {event, ..} => {
-                            if let Some(keycode) =
-                                KeyCode::try_from_winit(event.physical_key)
-                            {
-                                match event.state {
-                                    ElementState::Pressed => {
-                                        let mut state =
-                                            GLOBAL_STATE.borrow_mut();
-
-                                        state.pressed.insert(keycode);
-                                        state.just_pressed.insert(keycode);
-                                        state.just_released.remove(&keycode);
-                                    }
-
-                                    ElementState::Released => {
-                                        let mut state =
-                                            GLOBAL_STATE.borrow_mut();
-
-                                        state.pressed.remove(&keycode);
-                                        state.just_pressed.remove(&keycode);
-                                        state.just_released.insert(keycode);
-                                    }
-                                }
-                            }
-                        }
-
                         WindowEvent::Resized(physical_size) => {
                             if physical_size.width > min_resolution.0 &&
                                 physical_size.height > min_resolution.1

--- a/comfy/src/game_loop.rs
+++ b/comfy/src/game_loop.rs
@@ -147,7 +147,7 @@ pub async fn run_comfy_main_async(
                 Event::AboutToWait => {
                     let _span = span!("frame with vsync");
                     #[cfg(not(target_arch = "wasm32"))]
-                        let _ = loop_helper.loop_start();
+                    let _ = loop_helper.loop_start();
                     let frame_start = Instant::now();
 
                     set_delta(delta);

--- a/comfy/src/game_loop.rs
+++ b/comfy/src/game_loop.rs
@@ -299,7 +299,7 @@ pub async fn run_comfy_main_async(
                             }
                         }
                         
-                        WindowEvent::KeyboardInput {event, ..} => {
+                        WindowEvent::KeyboardInput { event, .. } => {
                             if let Some(keycode) =
                                 KeyCode::try_from_winit(event.physical_key)
                             {

--- a/comfy/src/game_loop.rs
+++ b/comfy/src/game_loop.rs
@@ -147,7 +147,7 @@ pub async fn run_comfy_main_async(
                 Event::AboutToWait => {
                     let _span = span!("frame with vsync");
                     #[cfg(not(target_arch = "wasm32"))]
-                    let _ = loop_helper.loop_start();
+                        let _ = loop_helper.loop_start();
                     let frame_start = Instant::now();
 
                     set_delta(delta);
@@ -215,36 +215,6 @@ pub async fn run_comfy_main_async(
                     tracy_client::frame_mark();
                 }
 
-                Event::DeviceEvent { event, .. } => {
-                    match event {
-                        DeviceEvent::Key(input) => {
-                            if let Some(keycode) =
-                                KeyCode::try_from_winit(input.physical_key)
-                            {
-                                match input.state {
-                                    ElementState::Pressed => {
-                                        let mut state =
-                                            GLOBAL_STATE.borrow_mut();
-
-                                        state.pressed.insert(keycode);
-                                        state.just_pressed.insert(keycode);
-                                        state.just_released.remove(&keycode);
-                                    }
-
-                                    ElementState::Released => {
-                                        let mut state =
-                                            GLOBAL_STATE.borrow_mut();
-
-                                        state.pressed.remove(&keycode);
-                                        state.just_pressed.remove(&keycode);
-                                        state.just_released.insert(keycode);
-                                    }
-                                }
-                            }
-                        }
-                        _ => {}
-                    }
-                }
                 Event::WindowEvent { ref event, window_id: _ } => {
                     if engine.renderer.as_mut().unwrap().on_event(event, egui())
                     {
@@ -325,6 +295,32 @@ pub async fn run_comfy_main_async(
                                          implemented! {:?}",
                                         delta
                                     );
+                                }
+                            }
+                        }
+                        
+                        WindowEvent::KeyboardInput {event, ..} => {
+                            if let Some(keycode) =
+                                KeyCode::try_from_winit(event.physical_key)
+                            {
+                                match event.state {
+                                    ElementState::Pressed => {
+                                        let mut state =
+                                            GLOBAL_STATE.borrow_mut();
+
+                                        state.pressed.insert(keycode);
+                                        state.just_pressed.insert(keycode);
+                                        state.just_released.remove(&keycode);
+                                    }
+
+                                    ElementState::Released => {
+                                        let mut state =
+                                            GLOBAL_STATE.borrow_mut();
+
+                                        state.pressed.remove(&keycode);
+                                        state.just_pressed.remove(&keycode);
+                                        state.just_released.insert(keycode);
+                                    }
                                 }
                             }
                         }

--- a/comfy/src/game_loop.rs
+++ b/comfy/src/game_loop.rs
@@ -222,32 +222,6 @@ pub async fn run_comfy_main_async(
                     }
 
                     match event {
-                        WindowEvent::KeyboardInput {event, ..} => {
-                            if let Some(keycode) =
-                                KeyCode::try_from_winit(event.physical_key)
-                            {
-                                match event.state {
-                                    ElementState::Pressed => {
-                                        let mut state =
-                                            GLOBAL_STATE.borrow_mut();
-
-                                        state.pressed.insert(keycode);
-                                        state.just_pressed.insert(keycode);
-                                        state.just_released.remove(&keycode);
-                                    }
-
-                                    ElementState::Released => {
-                                        let mut state =
-                                            GLOBAL_STATE.borrow_mut();
-
-                                        state.pressed.remove(&keycode);
-                                        state.just_pressed.remove(&keycode);
-                                        state.just_released.insert(keycode);
-                                    }
-                                }
-                            }
-                        }
-
                         WindowEvent::CursorMoved { position, .. } => {
                             let mut global_state = GLOBAL_STATE.borrow_mut();
 
@@ -325,6 +299,32 @@ pub async fn run_comfy_main_async(
                             }
                         }
                         
+                        WindowEvent::KeyboardInput {event, ..} => {
+                            if let Some(keycode) =
+                                KeyCode::try_from_winit(event.physical_key)
+                            {
+                                match event.state {
+                                    ElementState::Pressed => {
+                                        let mut state =
+                                            GLOBAL_STATE.borrow_mut();
+
+                                        state.pressed.insert(keycode);
+                                        state.just_pressed.insert(keycode);
+                                        state.just_released.remove(&keycode);
+                                    }
+
+                                    ElementState::Released => {
+                                        let mut state =
+                                            GLOBAL_STATE.borrow_mut();
+
+                                        state.pressed.remove(&keycode);
+                                        state.just_pressed.remove(&keycode);
+                                        state.just_released.insert(keycode);
+                                    }
+                                }
+                            }
+                        }
+
                         WindowEvent::Resized(physical_size) => {
                             if physical_size.width > min_resolution.0 &&
                                 physical_size.height > min_resolution.1

--- a/comfy/src/game_loop.rs
+++ b/comfy/src/game_loop.rs
@@ -298,7 +298,7 @@ pub async fn run_comfy_main_async(
                                 }
                             }
                         }
-                        
+
                         WindowEvent::KeyboardInput { event, .. } => {
                             if let Some(keycode) =
                                 KeyCode::try_from_winit(event.physical_key)


### PR DESCRIPTION
To be honest I'm not sure whether this is the correct way to fix this, but it seems that #101  is caused by https://github.com/darthdeus/comfy/commit/cd52f9f3db6b2e5db260ad35e4a59894e90ef727 which moved the keyboard event handling to use `Event::DeviceEvent` instead of `Event::WindowEvent` -> `WindowEvent::KeyboardInput`. In my testing `Event::DeviceEvent` is _not_ fired when pressing keys (on macOS). This doesn't revert the above commit, it merely moves the code to use `WindowEvent::KeyboardInput` instead.

Fixes #101 