### PR TITLE
Fix: errors when wasm32 is targeted.

### DIFF
--- a/comfy-wgpu/src/device.rs
+++ b/comfy-wgpu/src/device.rs
@@ -68,7 +68,7 @@ pub async fn create_graphics_context(
         .await
         .expect("failed to create wgpu adapter");
 
-    #[cfg(fature = "ci-release")]
+    #[cfg(feature = "ci-release")]
     device.on_uncaptured_error(Box::new(|err| {
         error!("WGPU ERROR: {:?}", err);
         panic!("Exiting due to wgpu error: {:?}", err);

--- a/comfy/src/game_loop.rs
+++ b/comfy/src/game_loop.rs
@@ -92,7 +92,7 @@ pub async fn run_comfy_main_async(
         // Winit prevents sizing with CSS, so we have to set
         // the size manually when on web.
         use winit::dpi::PhysicalSize;
-        window.set_inner_size(PhysicalSize::new(
+        let _ = window.request_inner_size(PhysicalSize::new(
             resolution.width(),
             resolution.height(),
         ));
@@ -104,12 +104,14 @@ pub async fn run_comfy_main_async(
                 match &game_config().wasm_append_id {
                     Some(id) => {
                         let dst = doc.get_element_by_id(&id)?;
-                        let canvas = web_sys::Element::from(window.canvas());
+                        let canvas = 
+                            web_sys::Element::from(window.canvas().unwrap());
                         dst.append_child(&canvas).ok()?;
                     }
                     _ => {
                         let dst = doc.body()?;
-                        let canvas = web_sys::Element::from(window.canvas());
+                        let canvas = web_sys::
+                            Element::from(window.canvas().unwrap());
                         dst.append_child(&canvas).ok()?;
                     }
                 };

--- a/comfy/src/game_loop.rs
+++ b/comfy/src/game_loop.rs
@@ -101,17 +101,15 @@ pub async fn run_comfy_main_async(
         web_sys::window()
             .and_then(|win| win.document())
             .and_then(|doc| {
+                let canvas = web_sys::Element::from(window.canvas().unwrap());
+
                 match &game_config().wasm_append_id {
                     Some(id) => {
                         let dst = doc.get_element_by_id(&id)?;
-                        let canvas = 
-                            web_sys::Element::from(window.canvas().unwrap());
                         dst.append_child(&canvas).ok()?;
                     }
                     _ => {
                         let dst = doc.body()?;
-                        let canvas = web_sys::
-                            Element::from(window.canvas().unwrap());
                         dst.append_child(&canvas).ok()?;
                     }
                 };


### PR DESCRIPTION
There were compilation issues when target is `wasm32-unknown-unknown` due to:
- `Window::set_inner_size` being used while not being defined instead of `Window::request_inner_size`
- `window.canvas()` not being unwrapped before being `Into`ed

There were unreachable code due to misspellings of  `feature` in `comfy-wgpu`.